### PR TITLE
PDEV-1935 Inject AWS client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+Categories: Removed, Changed, Added, Deprecated, Fixed, Security, Nonfunctional
+
+## Unreleased
+
+### Changed
+- PDEV-1935 - `DynamodbStorage` and `LambdaSnsExecutor` require `DynamoDB` and `SNS` clients to be injected respectively.

--- a/executor/lambdaSnsExecutor.js
+++ b/executor/lambdaSnsExecutor.js
@@ -1,8 +1,6 @@
-import aws from 'aws-sdk'
-
 export default class LambdaSnsExecutor {
-  constructor (topicArn) {
-    this._sns = new aws.SNS({ params: { TopicArn: topicArn } })
+  constructor (SNS, topicArn) {
+    this._sns = new SNS({ params: { TopicArn: topicArn } })
   }
 
   runTask (handler, event, context, callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,118 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "aws-sdk": {
-      "version": "2.149.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.149.0.tgz",
-      "integrity": "sha1-dvU3Iqd4C9sxkeg/J8EBCMb+mBM=",
-      "requires": {
-        "buffer": "4.9.1",
-        "crypto-browserify": "1.0.9",
-        "events": "1.1.1",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.1.0",
-        "xml2js": "0.4.17",
-        "xmlbuilder": "4.2.1"
-      }
-    },
-    "base64-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
-    },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      }
-    },
-    "crypto-browserify": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz",
-      "integrity": "sha1-zFRJaF37hesRyYKKzHy4erW7/MA="
-    },
     "dynamodb-data-types": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/dynamodb-data-types/-/dynamodb-data-types-3.0.0.tgz",
       "integrity": "sha1-Ldo/8qiEYuBdJzi+WJAuIx2TYQM="
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
-    "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-    },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-    },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-      "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "requires": {
-        "lodash": "4.17.4"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "url": "https://github.com/cloudreach-pdev/flow.git"
   },
   "dependencies": {
-    "aws-sdk": "^2.149.0",
     "dynamodb-data-types": "^3.0.0",
     "uuid": "^3.1.0"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "peerDependencies": {
+    "aws-sdk": "^2.149.0"
+  }
 }

--- a/storage/dynamodbStorage.js
+++ b/storage/dynamodbStorage.js
@@ -1,4 +1,3 @@
-import aws from 'aws-sdk'
 import dynamodbDataTypes, { AttributeValue as attr } from 'dynamodb-data-types'
 
 import { TaskAlreadyCompleteError } from '../medium'
@@ -6,10 +5,10 @@ import { TaskAlreadyCompleteError } from '../medium'
 dynamodbDataTypes.preserveArrays()
 
 export default class DynamodbStorage {
-  constructor (tableName) {
+  constructor (DynamoDB, tableName) {
     this._tableName = tableName
 
-    this._dynamodb = new aws.DynamoDB({ params: { TableName: tableName } })
+    this._dynamodb = new DynamoDB({ params: { TableName: tableName } })
   }
 
   insertTasks (tasks) {


### PR DESCRIPTION
Flow no longer has the AWS SDK has a dependency - instead, the DynamoDB storage expects the DynamoDB client to be passed in to its constructor. (This makes it much easier for users to configure their own client and use that).